### PR TITLE
remove sleeps

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 		if command == "demo" {
 			goatpress.Demo()
 		} else if command == "server" {
-			fmt.Printf("Web port:    %s\n", *webPort)
+			fmt.Printf("Web port:    %d\n", *webPort)
 			goatpress.ServerStart(*tournamentFile, *clientTimeout, *serverPort, *webPort)
 		} else if command == "client" {
 			fmt.Printf("Player name: %s\n", *playerName)


### PR DESCRIPTION
To remove sleeps (:sheep: :sheep:), I slightly reorganised the main tournament loop.
- I added tickers (channels that send a message every given time interval) to consistently ping idle clients, and find new matches.
- I added an attempt to join a game as soon as we get a new user. ( the ticker is still needed for connecting existing users)
